### PR TITLE
Weekly calendar data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1511,8 +1511,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "resolved": "",
           "dev": true
         },
         "schema-utils": {
@@ -2690,8 +2689,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "resolved": "",
           "dev": true
         },
         "schema-utils": {
@@ -5153,8 +5151,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "resolved": "",
           "dev": true
         },
         "strip-ansi": {
@@ -7132,8 +7129,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "resolved": "",
           "dev": true
         }
       }
@@ -8194,8 +8190,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "resolved": "",
           "dev": true
         },
         "schema-utils": {
@@ -9093,8 +9088,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "resolved": "",
           "dev": true
         }
       }

--- a/src/Repo.js
+++ b/src/Repo.js
@@ -159,8 +159,9 @@ class Repo {
     }, []);
   }
 
-  presentWeeks(date, id) {
+  presentWeek(date, id) {
     let allDates = this.sortUserDataByDate(id);
+    allDates = allDates.map(dataPoint => dataPoint.date)
     let i = allDates.indexOf(date);
     return allDates.slice(i, i + 7);
   }

--- a/src/Repo.js
+++ b/src/Repo.js
@@ -1,3 +1,5 @@
+import moment from 'moment';
+
 class Repo {
   constructor(users) {
     this.data;
@@ -7,60 +9,67 @@ class Repo {
     if (Array.isArray(data)) {
       this.data = data;
     }
-  } 
-  
+  }
 
   findById(id, date) {
-    if (typeof id !== 'number') {
-      return 'This id is incorrect'
-    } else if (typeof date !== 'string' || !this.dateRule(date)) {
-      return 'This date is improperly formatted'
+    if (typeof id !== "number") {
+      return "This id is incorrect";
+    } else if (typeof date !== "string" || !this.dateRule(date)) {
+      return "This date is improperly formatted";
     }
 
-    return this.data.find(dataPoint => {
+    return this.data.find((dataPoint) => {
       return dataPoint.userID === id && dataPoint.date === date;
     });
   }
 
   dateRule(date) {
-    if (typeof date !== 'string') return false
-    date = date.split('/')
-    if (date[0].length === 4 && date[1].length === 2 && date[2].length === 2 
-      && date.every(number => parseInt(number))) {
-      return true
+    if (typeof date !== "string") return false;
+    date = date.split("/");
+    if (
+      date[0].length === 4 &&
+      date[1].length === 2 &&
+      date[2].length === 2 &&
+      date.every((number) => parseInt(number))
+    ) {
+      return true;
     } else {
-      return false
+      return false;
     }
   }
 
   keyRule(key) {
-    this.data.every(dataPoint => Object.keys(dataPoint).includes(key))
+    this.data.every((dataPoint) => Object.keys(dataPoint).includes(key));
   }
 
   getAllDataById(id) {
-    if (typeof id !== 'number') return "This id is incorrect"
-    return this.data.filter(dataPoint => dataPoint.userID === id)
+    if (typeof id !== "number") return "This id is incorrect";
+    return this.data.filter((dataPoint) => dataPoint.userID === id);
   }
- 
-  calculateAverage(key, id) { 
-    let average = this.data.reduce((average, dataPoint) => {
-      if (typeof id === 'number' && dataPoint.userID === id) {
-        let userSet = this.data.filter(dataPoint => dataPoint.userID === id)
-        average += dataPoint[key] / userSet.length
-        return average;
-      } else if (!id) {
-        average += dataPoint[key] / this.data.length;
-        return average;
-      } else {
-        return average;
-      }
-    }, 0).toFixed(1);
+
+  calculateAverage(key, id) {
+    let average = this.data
+      .reduce((average, dataPoint) => {
+        if (typeof id === "number" && dataPoint.userID === id) {
+          let userSet = this.data.filter(
+            (dataPoint) => dataPoint.userID === id
+          );
+          average += dataPoint[key] / userSet.length;
+          return average;
+        } else if (!id) {
+          average += dataPoint[key] / this.data.length;
+          return average;
+        } else {
+          return average;
+        }
+      }, 0)
+      .toFixed(1);
     return average;
   }
 
   sortUserDataByDate(id) {
-    if (typeof id !== 'number') return "This id is incorrect"
-    let selectedID = this.getAllDataById(id)
+    if (typeof id !== "number") return "This id is incorrect";
+    let selectedID = this.getAllDataById(id);
     return selectedID.sort((a, b) => new Date(b.date) - new Date(a.date));
   }
 
@@ -70,7 +79,7 @@ class Repo {
   }
 
   getToday(id) {
-    if (typeof id !== 'number') return "This id is incorrect"
+    if (typeof id !== "number") return "This id is incorrect";
     return this.sortUserDataByDate(id)[0].date;
   }
 
@@ -79,52 +88,85 @@ class Repo {
   }
 
   getAllDataByDay(date) {
-    if (!this.dateRule(date)) return 'This date is improperly formatted'
-    return this.data.filter(dataItem => {
-      return dataItem.date === date
+    if (!this.dateRule(date)) return "This date is improperly formatted";
+    return this.data.filter((dataItem) => {
+      return dataItem.date === date;
     });
-  } 
-
-  getAllDataByWeek(date) { 
-    return this.data.filter(dataItem => {
-      // next line needs to get broken up
-
-      return (new Date(date)).setDate((new Date(date)).getDate() - 7) <= new Date(dataItem.date) && new Date(dataItem.date) <= new Date(date)
-    })
   }
 
-  getUserDataByWeek(date, id) {  // returns a slice of a sorted array, with entire dataPoints. [{act} {act} ...]
+  getAllDataByWeek(date) {
+    return this.data.filter((dataItem) => {
+      // next line needs to get broken up
+
+      return (
+        new Date(date).setDate(new Date(date).getDate() - 7) <=
+          new Date(dataItem.date) && new Date(dataItem.date) <= new Date(date)
+      );
+    });
+  }
+
+  getUserDataByWeek(date, id) {
+    // returns a slice of a sorted array, with entire dataPoints. [{act} {act} ...]
     let userDataByDate = this.sortUserDataByDate(id, this.data);
-    let dateIndex = userDataByDate.indexOf(userDataByDate.find(firstItem => firstItem.date === date));
+    let dateIndex = userDataByDate.indexOf(
+      userDataByDate.find((firstItem) => firstItem.date === date)
+    );
     return userDataByDate.slice(dateIndex, dateIndex + 7);
   }
 
   getUserAverageForWeek(id, date, key) {
     if (!this.dateRule(date)) {
-      return 'This date is improperly formatted'
-    } else if (typeof id !== 'number') {
-      return 'This id is not properly formatted'
+      return "This date is improperly formatted";
+    } else if (typeof id !== "number") {
+      return "This id is not properly formatted";
     } else if (this.keyRule(key) === false) {
-      return 'The key does not correspond with the dataset'
+      return "The key does not correspond with the dataset";
     }
 
-    let weekData = this.getUserDataByWeek(date, id)
-    return parseFloat(weekData.reduce((average, dataPoint) => {
-      average = average + dataPoint[key] / weekData.length
-      return average
-    }, 0).toFixed(1));
+    let weekData = this.getUserDataByWeek(date, id);
+    return parseFloat(
+      weekData
+        .reduce((average, dataPoint) => {
+          average = average + dataPoint[key] / weekData.length;
+          return average;
+        }, 0)
+        .toFixed(1)
+    );
   }
 
   getAllUserAverageForDay(date, key) {
-    if(!this.dateRule(date) || this.keyRule(key) === false) {
-      return 'One of the parameters are incorrect'
+    if (!this.dateRule(date) || this.keyRule(key) === false) {
+      return "One of the parameters are incorrect";
     }
     let selectedDayData = this.getAllDataByDay(date);
-    return parseFloat(selectedDayData.reduce((average, data) => {
-      average = average + data[key] / selectedDayData.length
-      return average;
-    }, 0).toFixed(1));
+    return parseFloat(
+      selectedDayData
+        .reduce((average, data) => {
+          average = average + data[key] / selectedDayData.length;
+          return average;
+        }, 0)
+        .toFixed(1)
+    );
+  }
+
+  findWeeklyStartDates(id) {
+    const sortedData = this.sortDataByDate(id);
+    return sortedData.reduce((mondays, dataPoint) => {
+      if (moment(dataPoint.date).format("dddd") === "Monday") {
+        mondays.push(dataPoint.date);
+      }
+      return mondays;
+    }, []);
+  }
+
+  presentWeeks(date, id) {
+    let allDates = this.sortUserDataByDate(id);
+    let i = allDates.indexOf(date);
+    return allDates.slice(i, i + 7);
   }
 }
 
 export default Repo
+
+// var date = "2020/07/24";
+// var test = moment(date).format("dddd");

--- a/src/css/_card-design.scss
+++ b/src/css/_card-design.scss
@@ -27,7 +27,7 @@
   flex-direction: column;
   background-color: $white;
   border-radius: 5%;
-  height: 40%;
+  height: auto;
   width: 85%;
   margin: 0 2.5% 2.5%;
 

--- a/src/css/style.scss
+++ b/src/css/style.scss
@@ -66,7 +66,6 @@ table {
   margin: 0;
   display: flex;
   flex-direction: column;
-  overflow: scroll;
 }
 
 .number {

--- a/src/index.html
+++ b/src/index.html
@@ -71,10 +71,10 @@
              </option>
              </select>
              <section class="calendar-container" tabindex="0">
-               <nav id="weekly-data-options">
-                 <button class ="hydration-week-data-button hidden" id="weekly-hydration ">Hydration</button>
-                 <button class ="activity-week-data-button hidden" id="weekly-activity ">Activity</button>
-                 <button class ="sleep-week-data-button hidden" id="weekly-sleep ">Sleep</button>
+               <nav class="weekly-nav" id="weekly-data-options">
+                 <button class="hidden" id="weekly-hydration">Hydration</button>
+                 <button class="hidden" id="weekly-activity">Activity</button>
+                 <button class="hidden" id="weekly-sleep">Sleep</button>
                </nav>
                <table>
                  <tr>

--- a/src/index.html
+++ b/src/index.html
@@ -15,7 +15,7 @@
       </section>
       <section class="body-main-infoContainter" tabindex="0">
         <h2 id="app-message" tabindex="0">A message for the user</h2>
-        <section class="card-container" id="daily-cards" tabindex="0">
+        <section class="card-container hidden" id="daily-cards" tabindex="0">
           <h3 tabindex="0">Daily Fitness</h3>
           <section class="card hydration-card" id="hydration-today" tabindex="0">
               You drank
@@ -53,7 +53,7 @@
           <section class="main-column-activity"></section>
           <section class="main-column-sleep"></section> -->
         </section>
-        <section class="card-container hidden" id="user-cards" tabindex="0">
+        <section class="card-container" id="user-cards" tabindex="0">
           <h2>User / Account</h2>
           <section class="card" id="user-goals" tabindex="0">
             user goals:<button id="update-goals">Update Info</button>
@@ -64,10 +64,10 @@
           <section class="week-card" id="user-trends" tabindex="0">
             <label>
               Use to select the week
-              <select name="week" id="week-select">
             </label>
-             <option value='date'>
-               boy howdy how are we gonna populate weeks to choose from
+              <select name="week" id="week-select">
+             <option value='blank'>
+               --
              </option>
              </select>
              <section class="calendar-container" tabindex="0">
@@ -78,13 +78,13 @@
                </nav>
                <table>
                  <tr>
-                   <th>Monday</th>
-                   <th>Tuesday</th>
-                   <th>Wednesday</th>
-                   <th>Thursday</th>
-                   <th>Friday</th>
-                   <th>Saturday</th>
-                   <th>Sunday</th>
+                   <th id="mon-date">Monday</th>
+                   <th id="tues-date">Tuesday</th>
+                   <th id="weds-date">Wednesday</th>
+                   <th id="thurs-date">Thursday</th>
+                   <th id="fri-date">Friday</th>
+                   <th id="sat-date">Saturday</th>
+                   <th id="sun-date">Sunday</th>
                   </tr>
                   <tr>
                     <th class="historic-data" id="monday-data"></th>

--- a/src/index.html
+++ b/src/index.html
@@ -72,9 +72,9 @@
              </select>
              <section class="calendar-container" tabindex="0">
                <nav id="weekly-data-options">
-                 <button id="weekly-hydration">Hydration</button>
-                 <button id="weekly-activity">Activity</button>
-                 <button id="weekly-sleep">Sleep</button>
+                 <button class ="hydration-week-data-button hidden" id="weekly-hydration ">Hydration</button>
+                 <button class ="activity-week-data-button hidden" id="weekly-activity ">Activity</button>
+                 <button class ="sleep-week-data-button hidden" id="weekly-sleep ">Sleep</button>
                </nav>
                <table>
                  <tr>

--- a/src/page-manipulation.js
+++ b/src/page-manipulation.js
@@ -2,7 +2,7 @@ import moment from 'moment'
 
 function populateWeeklyDates(repo, id) {
   let mondays = repo.findWeeklyStartDates(id)
-  let selectBar = document.querySelector('#week-select')
+  let select = document.querySelector('#week-select')
   let options = mondays.reduce((week, monday) => {
     week += `
     <option value="${monday}>
@@ -10,8 +10,7 @@ function populateWeeklyDates(repo, id) {
     </option>`
     return week
   }, '')
-  console.log(mondays.length)
-  selectBar.insertAdjacentHTML('beforeend', options)
+  select.insertAdjacentHTML('beforeend', options)
 }
 
 function insertForm(event) {

--- a/src/page-manipulation.js
+++ b/src/page-manipulation.js
@@ -1,3 +1,12 @@
+function populateWeeklyDates(repo, id) {
+  let mondays = repo.findWeeklyStartDates(id)
+  let selectBar = document.querySelector('select')
+  mondays.forEach(monday => {
+    let week = `Week of ${moment(monday).format('MMMM Do YYYY')}`
+    selectBar.insertAdjacentHTML('beforeend', week)
+  })
+}
+
 function insertForm(event) {
   const dateInput = `date: <input id="date" />`;
   event.target.parentElement.insertAdjacentHTML('afterbegin', dateInput);
@@ -171,4 +180,10 @@ function addFriendSidebar(id, activityInfo, userStorage, dateString, laterDateSt
 
 
 
-export {populateDailyData, insertWeeklyDataLayouts, addInfoToUserSidebar, addFriendSidebar, insertForm}
+export {
+  populateDailyData, 
+  insertWeeklyDataLayouts, 
+  populateWeeklyDates, 
+  addInfoToUserSidebar, 
+  addFriendSidebar, 
+  insertForm}

--- a/src/page-manipulation.js
+++ b/src/page-manipulation.js
@@ -1,16 +1,19 @@
 import moment from 'moment'
+// import subtract from 'moment'
 
 function populateWeeklyDates(repo, id) {
-  let mondays = repo.findWeeklyStartDates(id)
-  let select = document.querySelector('#week-select')
+  const mondays = repo.findWeeklyStartDates(id);
+  console.log(mondays);
+  const select = document.querySelector("#week-select");
   let options = mondays.reduce((week, monday) => {
+    const momentMonday = moment(monday).format('MMMM Do YYYY')
     week += `
     <option value="${monday}>
-      Week of ${moment(monday).format('MMMM Do YYYY')}
-    </option>`
-    return week
-  }, '')
-  select.insertAdjacentHTML('beforeend', options)
+      Week of ${momentMonday}
+    </option>`;
+    return week;
+  }, "");
+  select.insertAdjacentHTML("beforeend", options);
 }
 
 function insertForm(event) {
@@ -29,7 +32,7 @@ function insertForm(event) {
 }
 
 function populateDailyData(card, repo, userId, date) {
-  const location = document.getElementById(card);
+  let location = document.getElementById(card);
   const innerElements = location.children;
   for(var i = 0; i < innerElements.length; i++) {
     let key = innerElements[i].id.split('-')[0]
@@ -41,26 +44,42 @@ function populateDailyData(card, repo, userId, date) {
   }
 }
 
-function insertWeeklyDataLayouts(event) {
+const insertWeekLayout = (html) => {
   const weekdays = document.querySelectorAll('.historic-data');
-  const hydrationWeekdayHtml = `<span class="number">0</span> oz drank`;
-  const activityWeekdayHtml =  `Step Count: <span class="number">0</span>
-    Stair Count: <span class="number">0</span>
-    Minutes Active: <span class="number">0</span>`
-  const sleepWeekdayHtml = `Hours Asleep: <span class="number">0</span>
-    Sleep Quality: <span class="number">0</span>out of 5`
-  const insertLayout = (html) => {
-    for (var i = 0; i < weekdays.length; i++) {
-      weekdays[i].innerHTML = html;
-    }
-  };
-  if (event.target.id.includes('hydration')) {
-    insertLayout(hydrationWeekdayHtml);
-  } else if (event.target.id.includes('activity')) {
-    insertLayout(activityWeekdayHtml);
-  } else if (event.target.id.includes('sleep')) {
-    insertLayout(sleepWeekdayHtml);
+  for (var i = 0; i < weekdays.length; i++) {
+    weekdays[i].innerHTML = html;
   }
+};
+
+function createWeeklyLayoutHtml() {
+  return {
+    'weekly-hydration': `
+      <span class="number" id="numOunces">
+        0
+      </span> oz drank`,
+    'weekly-activity': `Step Count: <span class="number" id="numSteps">0</span>
+      Stair Count: <span class="number" id="flightsOfStairs">0</span>
+      Minutes Active: <span class="number" id="minutesActive">0</span>`,
+    'weekly-sleep': `Hours Asleep: <span class="number" id="hoursSlept">0</span>
+        Sleep Quality: <span class="number" id="sleepQuality">0</span>out of 5`
+  }
+}
+
+function populateWeeklyData(repo, userId) {
+  const calendar = document.querySelectorAll('.historic-data')
+  let date = document.querySelector('select').value
+  date = date.slice(0, 10)
+  let week = repo.presentWeek(date, userId)
+  for(var i = 0; i < 8; i++) {
+    populateDailyData(calendar[i].id, repo, userId, week[i]);
+  }
+}
+
+function displayWeeklyData(event, repo, id) {
+  debugger
+  let weeklyHtml = createWeeklyLayoutHtml()
+  insertWeekLayout(weeklyHtml[event.target.id])
+  populateWeeklyData(repo, id)
 }
 
 function makeFriendHTML(user, userStorage) {
@@ -185,7 +204,7 @@ function addFriendSidebar(id, activityInfo, userStorage, dateString, laterDateSt
 
 export {
   populateDailyData, 
-  insertWeeklyDataLayouts, 
+  displayWeeklyData, 
   populateWeeklyDates, 
   addInfoToUserSidebar, 
   addFriendSidebar, 

--- a/src/page-manipulation.js
+++ b/src/page-manipulation.js
@@ -1,10 +1,17 @@
+import moment from 'moment'
+
 function populateWeeklyDates(repo, id) {
   let mondays = repo.findWeeklyStartDates(id)
-  let selectBar = document.querySelector('select')
-  mondays.forEach(monday => {
-    let week = `Week of ${moment(monday).format('MMMM Do YYYY')}`
-    selectBar.insertAdjacentHTML('beforeend', week)
-  })
+  let selectBar = document.querySelector('#week-select')
+  let options = mondays.reduce((week, monday) => {
+    week += `
+    <option value="${monday}>
+      Week of ${moment(monday).format('MMMM Do YYYY')}
+    </option>`
+    return week
+  }, '')
+  console.log(mondays.length)
+  selectBar.insertAdjacentHTML('beforeend', options)
 }
 
 function insertForm(event) {
@@ -177,13 +184,11 @@ function addFriendSidebar(id, activityInfo, userStorage, dateString, laterDateSt
   );
 }
 
-
-
-
 export {
   populateDailyData, 
   insertWeeklyDataLayouts, 
   populateWeeklyDates, 
   addInfoToUserSidebar, 
   addFriendSidebar, 
-  insertForm}
+  insertForm
+}

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -35,7 +35,10 @@ function startApp() {
   catchAllData('userData', 'hydrationData', 'sleepData', 'activityData');
 }
 
+const selectBar = document.querySelector('#week-select')
 const buttons = document.querySelectorAll('button');
+
+selectBar.addEventListener('click', selectHandler)
 for(const button of buttons) {
   button.addEventListener('click', buttonHandler);
 }
@@ -49,6 +52,22 @@ function buttonHandler(event) {
   } else if (event.target.id.includes('weekly')) {
     insertWeeklyDataLayouts(event);
   }
+}
+
+function selectHandler(event) {
+  unHideElements(
+    '.sleep-week-data-button', 
+    '.activity-week-data-button', 
+    '.hydration-week-data-button'
+    )
+}
+
+function unHideElements() {
+  const args = Array.from(arguments)
+  args.forEach(element => {
+    console.log(document.querySelector(element).classList.remove('hidden'))
+  })
+
 }
 
 function catchAllData() {

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -13,7 +13,7 @@ import {
   populateWeeklyDates,
   addInfoToUserSidebar,
   insertForm, 
-  insertWeeklyDataLayouts,
+  displayWeeklyData,
   addFriendSidebar
 } from './page-manipulation';
 
@@ -44,21 +44,32 @@ for(const button of buttons) {
 }
 
 function buttonHandler(event) {
+  let repoPass = determineRepo(event)
   if (event.target.id.includes('new')) {
     // originalCardContent = event.target.parentElement.innerHTML;
     insertForm(event);
   } else if (event.target.id === 'submit') {
     console.log(`run populate data, POST function, and do something with new date information.`)
   } else if (event.target.id.includes('weekly')) {
-    insertWeeklyDataLayouts(event);
+    displayWeeklyData(event, repoPass, currentUserId);
+  }
+}
+
+function determineRepo(event) {
+  if (event.target.id.includes("hydration")) {
+    return hydrationRepo;
+  } else if (event.target.id.includes("sleep")) {
+    return sleepRepo;
+  } else if (event.target.id.includes("activity")) {
+    return activityRepo;
   }
 }
 
 function selectHandler(event) {
   unHideElements(
-    '.sleep-week-data-button', 
-    '.activity-week-data-button', 
-    '.hydration-week-data-button'
+    '#weekly-hydration', 
+    '#weekly-activity', 
+    '#weekly-sleep'
     )
 }
 
@@ -81,7 +92,7 @@ function catchData(src) {
     .then(response => response.json())
     .then(data => data[src])
     .then(result => classInfo.class.storeData(result, src))
-    .then(repo => dataEventHandler(src));
+    .then(repo => dataEventHandler(src))
 }
 
 function dataEventHandler(src) {

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -15,7 +15,8 @@ import {
   insertWeeklyDataLayouts,
   addFriendSidebar
 } from './page-manipulation';
-import Repo from './Repo';
+
+import moment from 'moment'
 
 const userRepo = new UserRepo();
 const hydrationRepo = new Repo();
@@ -63,23 +64,20 @@ function catchData(src) {
     .then(repo => dataEventHandler(src));
 }
 
-
 function dataEventHandler(src) {
   if (src === 'userData') {
-    today = hydrationRepo.getToday(currentUserId)
     console.log(userRepo);
   } else if (src === 'hydrationData') {
     today = hydrationRepo.getToday(currentUserId)
     populateDailyData('hydration-today', hydrationRepo, currentUserId, today)
+    
     console.log(hydrationRepo);
   } else if (src === 'sleepData') {
     today = sleepRepo.getToday(currentUserId)
     populateDailyData('sleep-today', sleepRepo, currentUserId, today)
-    console.log(sleepRepo);
   } else if (src === 'activityData') {
     today = activityRepo.getToday(currentUserId)
     populateDailyData('activity-today', activityRepo, currentUserId, today)
-    console.log(activityRepo); 
   }
 }
 

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -10,6 +10,7 @@ import Repo from './Repo'
 
 import {
   populateDailyData,
+  populateWeeklyDates,
   addInfoToUserSidebar,
   insertForm, 
   insertWeeklyDataLayouts,
@@ -66,12 +67,10 @@ function catchData(src) {
 
 function dataEventHandler(src) {
   if (src === 'userData') {
-    console.log(userRepo);
   } else if (src === 'hydrationData') {
     today = hydrationRepo.getToday(currentUserId)
     populateDailyData('hydration-today', hydrationRepo, currentUserId, today)
-    
-    console.log(hydrationRepo);
+    populateWeeklyDates(hydrationRepo, currentUserId)
   } else if (src === 'sleepData') {
     today = sleepRepo.getToday(currentUserId)
     populateDailyData('sleep-today', sleepRepo, currentUserId, today)

--- a/test/activityrepo-test.js
+++ b/test/activityrepo-test.js
@@ -208,7 +208,7 @@ describe('Activity', function() {
   });
 
 
-  it.only('should take in data', function() {
+  it('should take in data', function() {
     expect(activity.data[0].userID).to.eql(1);
     expect(activity.data[4].date).to.eql("2019/06/15");
     expect(activity.data[3].numSteps).to.eql(3486);
@@ -217,16 +217,16 @@ describe('Activity', function() {
     expect(userRepo.data[0].id).to.eql(1);
   });
 
-  it.only('should return the miles a given user has walked on a given date', function() {
+  it('should return the miles a given user has walked on a given date', function() {
     
     expect(activity.getMilesFromStepsByDate(1, "2019/06/15", userRepo)).to.eql(2.9);
   });
 
-  it.only('should return true/false if the given user met their step goal on a given day', function() {
+  it('should return true/false if the given user met their step goal on a given day', function() {
     expect(activity.accomplishStepGoal(4, "2019/06/15", userRepo)).to.eql(false);
   });
 
-  it.only('should return all days that a given user exceeded their step goal', function() {
+  it('should return all days that a given user exceeded their step goal', function() {
     expect(activity.getDaysGoalExceeded(1, userRepo)).to.eql([
       "2019/06/17",
       "2019/06/19",
@@ -237,15 +237,15 @@ describe('Activity', function() {
     ]);
   });
 
-  it.only('should return the highest number of stairs climbed in a day for all time', function() {
+  it('should return the highest number of stairs climbed in a day for all time', function() {
     expect(activity.getStairRecord(11)).to.eql(33);
   });
 
-  it.only('should show a 3-day increasing streak for a users step count', function () {
+  it('should show a 3-day increasing streak for a users step count', function () {
     expect(activity.getStreak(1, 'numSteps')).to.eql(['2019/06/17', '2019/06/18'])
   });
 
-  it.only('should show a 3-day increasing streak for a users minutes of activity', function () {
+  it('should show a 3-day increasing streak for a users minutes of activity', function () {
     expect(activity.getStreak(1, 'minutesActive')).to.eql(['2019/06/18'])
   });
 });

--- a/test/repo-test.js
+++ b/test/repo-test.js
@@ -283,4 +283,8 @@ describe('Repo', () => {
     expect(result).to.equal(22.5)
   })
   
+  it.only('should be able to return Mondays from a given users data', () => {
+    let result = sleepRepo.findWeeklyStartDates(3000)
+    expect(result).to.deep.equal([`2040/01/09`]);
+  })
 });


### PR DESCRIPTION
###### What's this PR do?
* Adds moment to the project again
* Populates dropdown with every Monday, or "week-of", from a given dataset. 
* Allows the user to select which dataset they want to view for the week they've selected
* Populates that data for each day on the calendar
###### Where should the reviewer start?
* run `npm install moment --save" in terminal
* page manipulation functions that support this feature could use some love
###### How should this be manually tested?
SPIES
###### What are the relevant tickets?
There should be, but I've definitely fallen behind in creating tickets.
###### Questions:
* is there a way to import the repos into the page-manipulation document to eliminate having to pass a repo as an argument for these functions?
* would a better route be to move these elements into a page-manipulator class?